### PR TITLE
chore(demo-nodejs): promote demo-nodejs-0.0.6

### DIFF
--- a/demo-nodejs/prod/values.yaml
+++ b/demo-nodejs/prod/values.yaml
@@ -5,7 +5,7 @@ environment: "prod"
 
 image:
   repository: mateotorres2409/mateotorres2409
-  tag: demo-nodejs-0.0.3
+  tag: demo-nodejs-0.0.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets:


### PR DESCRIPTION
Automated promotion for demo-nodejs.
New image tag: `demo-nodejs-0.0.6`
Merge to let ArgoCD sync.