### PR TITLE
chore(demo-nodejs): promote demo-nodejs-0.0.11

### DIFF
--- a/demo-nodejs/prod/values.yaml
+++ b/demo-nodejs/prod/values.yaml
@@ -5,7 +5,7 @@ environment: "prod"
 
 image:
   repository: mateotorres2409/mateotorres2409
-  tag: demo-nodejs-0.0.8
+  tag: demo-nodejs-0.0.11
   pullPolicy: IfNotPresent
 
 resources:
@@ -69,7 +69,7 @@ ingress:
   host: demo-nodejs.k8s.mateo.local
   secretName: demo-nodejs.k8s.mateo.local-tls-ingress
 
-gitCommit: 73804f5b2fd744633544a543de9e7d1161e883f8
+gitCommit: 17bef6beee2766e79d30c99093a2a46108801214
 
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "true"


### PR DESCRIPTION
Automated promotion for demo-nodejs.
New image tag: `demo-nodejs-0.0.11`
Merge to let ArgoCD sync.