### PR TITLE
chore(demo-nodejs): promote demo-nodejs-0.0.13

### DIFF
--- a/demo-nodejs/prod/values.yaml
+++ b/demo-nodejs/prod/values.yaml
@@ -5,7 +5,7 @@ environment: "prod"
 
 image:
   repository: mateotorres2409/mateotorres2409
-  tag: demo-nodejs-0.0.12
+  tag: demo-nodejs-0.0.13
   pullPolicy: IfNotPresent
 
 resources:
@@ -76,7 +76,7 @@ ingress:
   host: demo-nodejs.k8s.mateo.local
   secretName: demo-nodejs.k8s.mateo.local-tls-ingress
 
-gitCommit: 84965b51a902eaa223b9f2b42de01b5f64af6b7b
+gitCommit: 16df13e641dcdb695c3d4721dcfbaadbdf0f68e9
 
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "true"


### PR DESCRIPTION
Automated promotion for demo-nodejs.
New image tag: `demo-nodejs-0.0.13`
Merge to let ArgoCD sync.