### PR TITLE
chore(demo-python): promote demo-python-0.0.16

### DIFF
--- a/demo-python/prod/values.yaml
+++ b/demo-python/prod/values.yaml
@@ -5,7 +5,7 @@ environment: "prod"
 
 image:
   repository: mateotorres2409/mateotorres2409
-  tag: demo-python-0.0.14
+  tag: demo-python-0.0.16
   pullPolicy: IfNotPresent
 
 resources:
@@ -79,7 +79,7 @@ ingress:
   host: demo-python.k8s.mateo.local
   secretName: demo-python.k8s.mateo.local-tls-ingress
 
-gitCommit: 318234026ed8e393a06254ba2763e01611fea3ac
+gitCommit: 03910f5094fe07c2801fd6f56dbe50732cc6db17
 
 podAnnotations:
   instrumentation.opentelemetry.io/inject-python: "true"


### PR DESCRIPTION
Automated promotion for demo-python.
New image tag: `demo-python-0.0.16`
Merge to let ArgoCD sync.